### PR TITLE
use "EVAL" instead of deprecated "eval"

### DIFF
--- a/lib/Template/Mojo.pm
+++ b/lib/Template/Mojo.pm
@@ -77,7 +77,7 @@ class Template::Mojo {
         unless $m {
             die "Failed to parse the template"
         }
-        self.bless: :code(eval $m.ast)
+        self.bless: :code(EVAL $m.ast)
     }
 
     method render(*@a) {


### PR DESCRIPTION
Both niecza and rakudo support EVAL.
