### PR TITLE
Get rid of deprecated $fh.slurp

### DIFF
--- a/lib/Template/Mojo.pm
+++ b/lib/Template/Mojo.pm
@@ -93,8 +93,7 @@ A templating system modeled after the Perl 5 L<https://metacpan.org/module/Mojo:
 
 =head1 Synopsis
 
-    my $fh = open 'eg/template.tm', :r;
-    my $tmpl = $fh.slurp;
+    my $tmpl = slurp 'eg/template.tm';
 
     my $t = Template::Mojo.new($tmpl);
     $t.render()
@@ -111,8 +110,7 @@ A templating system modeled after the Perl 5 L<https://metacpan.org/module/Mojo:
 
 =head3 Code
 
-  my $fh = open 'eg/template.tm', :r;
-  my $tmpl = $fh.slurp;
+  my $tmpl = slurp 'eg/template.tm';
   my $t = Template::Mojo.new($tmpl);
   $t.render()
 
@@ -141,8 +139,7 @@ See, on the first row of the template we accept a parameter as if this was a gen
 
 The value to that subroutione can be passed in the render call:
 
-  my $fh = open 'eg/template.tm', :r;
-  my $tmpl = $fh.slurp;
+  my $tmpl = slurp 'eg/template.tm';
   my $t = Template::Mojo.new($tmpl);
   $t.render(5)
 
@@ -172,8 +169,7 @@ The value to that subroutione can be passed in the render call:
     lname => 'Bar',
   );
 
-  my $fh = open 'eg/template.tm', :r;
-  my $tmpl = $fh.slurp;
+  my $tmpl = slurp 'eg/template.tm';
   my $t = Template::Mojo.new($tmpl);
   $t.render(%params)
 
@@ -212,8 +208,7 @@ The value to that subroutione can be passed in the render call:
      ],
   );
 
-  my $fh = open 'eg/template.tm', :r;
-  my $tmpl = $fh.slurp;
+  my $tmpl = slurp 'eg/template.tm';
   my $t = Template::Mojo.new($tmpl);
   $t.render(%params)
 

--- a/t/01-template.t
+++ b/t/01-template.t
@@ -24,8 +24,7 @@ my @cases = (
 plan @cases.elems;
 
 for @cases -> $c {
-	my $fh = open "eg/$c<name>.tm", :r;
-	my $tmpl = $fh.slurp;
+	my $tmpl = slurp "eg/$c<name>.tm";
 	#diag $tmpl;
 	my $output;
 	if $c<params> {
@@ -43,8 +42,7 @@ for @cases -> $c {
 		$out.close;
 	}
 	
-	my $fh2 = open "eg/$c<name>.out", :r;
-	my $expected = $fh2.slurp;
+	my $expected = slurp "eg/$c<name>.out";
 	is $output, $expected, $c<name>;
 }
 

--- a/t/02-complex.t
+++ b/t/02-complex.t
@@ -21,8 +21,7 @@ plan 1;
 
 #diag %params.perl;
 
-my $fh = open "eg/complex.tm", :r;
-my $tmpl = $fh.slurp;
+my $tmpl = slurp "eg/complex.tm";
 #diag $tmpl;
 my $output = Template::Mojo.new($tmpl).render(%params);
 #diag $output;
@@ -35,7 +34,6 @@ if 0 {
 	$out.close;
 }
 	
-my $fh2 = open "eg/complex.out", :r;
-my $expected = $fh2.slurp;
+my $expected = slurp "eg/complex.out";
 is $output, $expected, 'complex';
 


### PR DESCRIPTION
since the file handle is used only for slurping, there is no need to
create it explicitly, using just "slurp $filename" is shorter (and
not deprecated)