### PR TITLE
Added 'provides' section

### DIFF
--- a/META.info
+++ b/META.info
@@ -2,6 +2,9 @@
     "name"        : "Template::Mojo",
     "version"     : "*",
     "description" : "A templating system similar to Perl 5's Mojo::Template",
+    "provides" : {
+        "Template::Mojo" : "lib/Template/Mojo.pm"
+    },
     "depends"     : [],
     "source-url"  : "git://github.com/tadzik/Template-Mojo.git"
 }


### PR DESCRIPTION
EDIT: check out pull #17 ; it fills out more info in META.info, along with the `provides`

=================================

This is to play nice with panda 11 that needs provides section.
```
==> Installing Template::Mojo
===WARNING!===
The distribution Template::Mojo does not seem to have a "provides" section in its META.info file,
and so the packages will not be installed in the correct location.
Please ask the author to add a "provides" section, mapping every exposed namespace to a
file location in the distribution.
See http://design.perl6.org/S22.html#provides for more information.
```
This fixes #14 