### PR TITLE
Add begin/end block capture feature similar to Mojo::Template

### DIFF
--- a/eg/capture.out
+++ b/eg/capture.out
@@ -1,0 +1,5 @@
+Hello World!
+Hello Bob!
+Hello Larry!
+Hello Fred!
+Hello George!

--- a/eg/capture.tm
+++ b/eg/capture.tm
@@ -1,0 +1,7 @@
+<% my &block = begin %>
+Hello <%= $^name %>!
+<% end %>
+
+% for 'World', 'Bob', 'Larry', 'Fred', 'George' {
+%= block($^name)
+% }

--- a/t/03-capture.t
+++ b/t/03-capture.t
@@ -1,0 +1,15 @@
+use v6;
+use Test;
+use Template::Mojo;
+
+my %params;
+
+plan 1;
+
+my $tmpl = slurp "eg/capture.tm";
+my $output = Template::Mojo.new($tmpl).render(%params);
+
+diag $output;
+
+my $expected = slurp "eg/capture.out";
+is $output, $expected, 'capture';


### PR DESCRIPTION
This works basically the same, but Perl 6 makes it a bit more powerful on it's
own so you can pass vars without shifting from @_ using the ^ twigil.

This is my very first work with Perl 6 grammars so feel free to make any suggestions on what I can do to improve what I've given. 

I thought about extending it further to add the ability to specify a signature, but I thought I'd stick with just simply matching what Mojo::Template is able to do for the first pull request.

Cheers.