### PR TITLE
use MONKEY-SEE-NO-EVAL;

### DIFF
--- a/lib/Template/Mojo.pm
+++ b/lib/Template/Mojo.pm
@@ -1,3 +1,4 @@
+use MONKEY-SEE-NO-EVAL;
 grammar Template::Mojo::Grammar {
     token TOP {
         ^ <expression>* $


### PR DESCRIPTION
EVAL doesn't work anymore unless this pragma is used:
use MONKEY-SEE-NO-EVAL;