### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl"          : "6",
     "name"          : "Template::Mojo",
+    "license"       : "MIT",
     "version"       : "v0.1",
     "description"   : "A templating system similar to Perl 5's Mojo::Template",
     "build-depends" : [],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license