### PR TITLE
slurp may return Failure, throw its exception immediately

### DIFF
--- a/lib/Template/Mojo.pm
+++ b/lib/Template/Mojo.pm
@@ -109,7 +109,7 @@ class Template::Mojo {
     has &.code;
 
     method from-file(Str $filename) {
-        my $tmpl = $filename.IO.slurp;
+        my $tmpl = $filename.IO.slurp.self;
         self.new($tmpl, name => $filename.IO.basename.split(".")[0]);
     }
 


### PR DESCRIPTION
Template::Mojo.from-file used to give a rather strange
exception when the file that's passed to it doesn't
exist:

Earlier failure:
 (HANDLED) Failed to open file [...]:
   No such file or directory
 [...]

Final error:
 Type check failed in binding to parameter '$tmpl';
 expected Str but got Failure (&CORE::infix:<orelse>...)
 [...]

This commit makes it throw the "Failed to open file"
bit immediately.